### PR TITLE
modify issue for failling db migration during bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,23 @@ ENV VERSION=13.0.1
 
 RUN set -x \
     && apt -y update \
-    && apt install -y libffi-dev python-dev libssl-dev default-mysql-client python-mysqldb \
-    && apt -y clean \
-    && pip install pymysql
+    && apt install -y libffi-dev python-dev libssl-dev default-mysql-client python-mysqldb vim \
+    && pip install pymysql \
+    && pip install uwsgi
 
-RUN curl -fSL https://github.com/openstack/keystone/archive/${VERSION}.tar.gz -o keystone-${VERSION}.tar.gz \
-    && tar xvf keystone-${VERSION}.tar.gz && cp -r ./keystone-13.0.1/etc/ /etc/keystone && cd keystone-${VERSION} \
-    && pip install -r requirements.txt \
-    && PBR_VERSION=${VERSION}  pip install . \
-    && pip install uwsgi \
-    && pip install python-openstackclient \
-    && cd - \
-    && rm -rf keystone-${VERSION}*
+RUN DEBIAN_FRONTEND=noninteractive apt install -y keystone
+
+#RUN curl -fSL https://github.com/openstack/keystone/archive/${VERSION}.tar.gz -o keystone-${VERSION}.tar.gz \
+#    && tar xvf keystone-${VERSION}.tar.gz && cp -r ./keystone-13.0.1/etc/ /etc/keystone && cd keystone-${VERSION} \
+#    && pip install -r requirements.txt \
+#    && PBR_VERSION=${VERSION}  pip install . \
+#    && pip install uwsgi \
+#    && pip install python-openstackclient \
+#    && cd - \
+#    && rm -rf keystone-${VERSION}*
 
 COPY keystone.conf /etc/keystone/keystone.conf
-COPY keystone.sql /root/keystone.sql
+#COPY keystone.sql /root/keystone.sql
 
 # Add bootstrap script and make it executable
 COPY bootstrap.sh /etc/bootstrap.sh
@@ -27,19 +29,3 @@ RUN chown root:root /etc/bootstrap.sh && chmod a+x /etc/bootstrap.sh
 WORKDIR /etc/keystone
 ENTRYPOINT ["/etc/bootstrap.sh"]
 EXPOSE 5000 35357
-
-#HEALTHCHECK --interval=10s --timeout=5s \
-#  CMD curl -f http://localhost:5000/v3 2> /dev/null || exit 1; \
-#  curl -f http://localhost:35357/v3 2> /dev/null || exit 1; \
-
-
-#######################################
-#
-# for VERSION, see https://releases.openstack.org/queens/index.html
-#
-# docker build -t openstack-keystone:queens .
-#
-# docker run -d -ti -p 35357:35357 --name keystone -p 5000:5000 openstack-keystone:queens
-#
-# curl http://localhost:5000/
-# curl http://localhost:5000/v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,15 @@ services:
     image: mysql:5.7
     ports:
       - "3306:3306"
-    volumes:
-      - "./.data/db:/var/lib/mysql"
+    #volumes:
+    #  - "./.data/db:/var/lib/mysql"
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: something_secret
+      # https://blog.mosuke.tech/entry/2018/04/21/basic-mysql-on-docker/
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: keystone
+      MYSQL_USER: keystone-admin
+      MYSQL_PASSWORD: keystone-pw
 
   keystone:
     depends_on:

--- a/keystone.conf
+++ b/keystone.conf
@@ -4,7 +4,7 @@ admin_token = 294a4c8a8a475f9b9836
 [database]
 # access to mysql by pymysql@python2
 # mysql+pymysql://keystone:[パスワード]@[db host name]
-connection = mysql+pymysql://keystone:something_secret@dockerkeystone_mysql_db_1
+connection = mysql+pymysql://keystone-admin:keystone-pw@dockerkeystone_mysql_db_1/keystone
 
 [token]
 provider = fernet

--- a/keystone.sql
+++ b/keystone.sql
@@ -1,5 +1,7 @@
 create database if not exists keystone;
+
 GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost' \
 IDENTIFIED BY 'KEYSTONE_DBPASS';
+
 GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%' \
 IDENTIFIED BY 'KEYSTONE_DBPASS';


### PR DESCRIPTION
- give up with manually install keystone from tarball
- now I can success with db migration during bootstrap
  - however keystone return internal server error in case of API req